### PR TITLE
Fix path resolution when invoked via symlink

### DIFF
--- a/bin/claude-usage
+++ b/bin/claude-usage
@@ -4,7 +4,15 @@ set -euo pipefail
 # Resolve library paths
 # Nix install: @LIB_DIR@ and @VIEWS_DIR@ are substituted at build time
 # Git install: use relative paths from this script's location
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Follow symlinks so relative paths work when invoked via a symlink
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SCRIPT_SOURCE" ]; do
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
+    SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+    # Handle relative symlink targets
+    [[ "$SCRIPT_SOURCE" != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
 
 LIB_DIR="@LIB_DIR@"
 VIEWS_DIR="@VIEWS_DIR@"


### PR DESCRIPTION
Resolve symlinks before computing SCRIPT_DIR so that relative paths
to lib/ and views/ resolve correctly when the binary is a symlink
(e.g. ~/.local/bin/claude-usage -> ~/.local/share/claude-usage-statusline/bin/claude-usage).

Fixes #1

https://claude.ai/code/session_01KRigENRKNMznDeXnQZyB7s