### PR TITLE
Fix missing "type": "command" in generated settings.json

### DIFF
--- a/bin/claude-usage
+++ b/bin/claude-usage
@@ -172,9 +172,9 @@ cmd_install_hook() {
         echo '{}' > "$settings_file"
     fi
 
-    # Use jq to set the statusLine.command
+    # Use jq to set the statusLine type and command
     local tmp="${settings_file}.tmp"
-    if jq --arg cmd "$cmd statusline" '.statusLine.command = $cmd' "$settings_file" > "$tmp"; then
+    if jq --arg cmd "$cmd statusline" '.statusLine.type = "command" | .statusLine.command = $cmd' "$settings_file" > "$tmp"; then
         mv "$tmp" "$settings_file"
     else
         rm -f "$tmp"


### PR DESCRIPTION
The install-hook command was only setting statusLine.command but not
statusLine.type, which Claude Code requires to be set to "command".

https://claude.ai/code/session_01AGMeQPQ341YJEp2Q7ski55